### PR TITLE
Allow to change pipelined function

### DIFF
--- a/lib/active_record/plsql/pipelined.rb
+++ b/lib/active_record/plsql/pipelined.rb
@@ -66,9 +66,7 @@ module ActiveRecord::PLSQL
       end
 
       def pipelined_function_name
-        return @full_function_name if defined? @full_function_name
-        package_name, function_name = @pipelined_function.package, @pipelined_function.procedure
-        @full_function_name = [package_name, function_name].compact.join('.')
+        [@pipelined_function.package, @pipelined_function.procedure].compact.join('.')
       end
 
       def arel_table


### PR DESCRIPTION
Example:
```
class SomeClass < ActiveRecord::PLSQL::Base
     self.pipelined_function = 'some_package.get_something'
     # some code
     self.pipelined_function = 'some_package.get_something_2'
end
```
The second call of self.pipelined_function will write into [table_name](https://github.com/flash-gordon/rails-plsql/blob/762a2184ffafcc8feb71b4505043b5b4e06ace43/lib/active_record/plsql/pipelined.rb#L65) wrong value because of [full_function_name](https://github.com/flash-gordon/rails-plsql/blob/762a2184ffafcc8feb71b4505043b5b4e06ace43/lib/active_record/plsql/pipelined.rb#L69) is already defined and it has old value of first pipelined_function call.
